### PR TITLE
Fixes DEVS-17 feat(ReactiveWorld): add core pub/sub system

### DIFF
--- a/Assets/Scripts/Runtime/ReactiveWorld.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 76455adf79b69544ca60372c1e0b2ccf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b170c23d98aca364594828aa469db8e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/AreaLightChangedEvent.cs
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/AreaLightChangedEvent.cs
@@ -1,0 +1,26 @@
+namespace Runtime.ReactiveWorld.Events
+{
+    /// <summary>
+    /// Event published when the lighting state of an area changes.
+    /// Allows interested reactors (UI, audio, gameplay...) to respond
+    /// without being directly coupled to the lighting system.
+    /// </summary>
+    public struct AreaLightChangedEvent : IWorldEvent
+    {
+        /// <summary>
+        /// Unique identifier of the area whose lighting has changed.
+        /// </summary>
+        public readonly string AreaId;
+
+        /// <summary>
+        /// New state of the area: <c>true</c> if the area is lit, <c>false</c> otherwise.
+        /// </summary>
+        public readonly bool IsLit;
+
+        public AreaLightChangedEvent(string areaId, bool isLit)
+        {
+            AreaId = areaId;
+            IsLit = isLit;
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/AreaLightChangedEvent.cs.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/AreaLightChangedEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 965cc8369cd415d46a432caf83ca7ade

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/IWorldEvent.cs
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/IWorldEvent.cs
@@ -1,0 +1,13 @@
+namespace Runtime.ReactiveWorld.Events
+{
+    /// <summary>
+    /// Marker interface for all reactive world events.
+    /// Allows the <see cref="WorldManager"/> to type and dispatch events
+    /// generically via the pub/sub pattern.
+    /// <para>
+    /// Any struct or class representing a game event must implement this interface.
+    /// Prefer <c>struct</c> for high-frequency events to avoid heap allocations.
+    /// </para>
+    /// </summary>
+    public interface IWorldEvent {}
+}

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/IWorldEvent.cs.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/IWorldEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 33e504f410384f74f86672a8173b4a9a

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/StructureChangedEvent.cs
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/StructureChangedEvent.cs
@@ -1,0 +1,27 @@
+namespace Runtime.ReactiveWorld.Events
+{
+    /// <summary>
+    /// Event published when the state of a world structure changes.
+    /// A structure can represent an obstacle, a mechanism, a platform, etc.
+    /// Subscribed reactors can adapt gameplay or the environment accordingly.
+    /// </summary>
+    public struct StructureChangedEvent : IWorldEvent
+    {
+        /// <summary>
+        /// Unique identifier of the structure that changed.
+        /// </summary>
+        public readonly string StructureId;
+
+        /// <summary>
+        /// New state of the structure: <c>true</c> if active/open/triggered, <c>false</c> otherwise.
+        /// The exact semantics depend on the type of structure.
+        /// </summary>
+        public readonly bool State;
+
+        public StructureChangedEvent(string structureId, bool state)
+        {
+            StructureId = structureId;
+            State = state;
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/ReactiveWorld/Events/StructureChangedEvent.cs.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Events/StructureChangedEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e19f96f0ac1d58148b792ea317bcf767

--- a/Assets/Scripts/Runtime/ReactiveWorld/Reactor.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Reactor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cda2f7c074a04d24fb7aefc64728f9e0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/ReactiveWorld/Reactor/IReactor.cs
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Reactor/IReactor.cs
@@ -1,0 +1,34 @@
+namespace Runtime.ReactiveWorld.Reactor
+{
+    /// <summary>
+    /// Base contract for any reactor in the ReactiveWorld system.
+    /// A reactor is a self-contained module that subscribes to world events
+    /// and responds accordingly. It is managed by the <see cref="WorldManager"/>.
+    /// </summary>
+    public interface IReactor
+    {
+        /// <summary>
+        /// Unique name identifying this reactor (useful for debugging and logging).
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Indicates whether this reactor is active. When disabled, it remains registered
+        /// in the <see cref="WorldManager"/> but is no longer solicited.
+        /// </summary>
+        bool IsEnabled { get; set; }
+
+        /// <summary>
+        /// Initializes the reactor and registers it with the <see cref="WorldManager"/>.
+        /// Event subscriptions should be set up here.
+        /// </summary>
+        /// <param name="worldManager">The central manager of the reactive world.</param>
+        void Initialize(WorldManager worldManager);
+
+        /// <summary>
+        /// Shuts down the reactor and unregisters it from the <see cref="WorldManager"/>.
+        /// Event subscriptions must be removed here to avoid memory leaks.
+        /// </summary>
+        void Shutdown();
+    }
+}

--- a/Assets/Scripts/Runtime/ReactiveWorld/Reactor/IReactor.cs.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/Reactor/IReactor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be969149a7c66eb419c5ba5c0f45caed

--- a/Assets/Scripts/Runtime/ReactiveWorld/WorldManager.cs
+++ b/Assets/Scripts/Runtime/ReactiveWorld/WorldManager.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using Runtime.ReactiveWorld.Reactor;
+using Runtime.ReactiveWorld.Events;
+using UnityEngine;
+
+namespace Runtime.ReactiveWorld
+{
+    /// <summary>
+    /// Central hub of the ReactiveWorld system.
+    /// Manages the lifecycle of <see cref="IReactor"/> instances and handles
+    /// typed event dispatching via a pub/sub pattern.
+    /// <para>
+    /// Reactors register themselves on <see cref="IReactor.Initialize"/> and
+    /// unregister on <see cref="IReactor.Shutdown"/>. Any system can publish
+    /// events via <see cref="Raise{TEvent}"/> without knowing who is listening.
+    /// </para>
+    /// </summary>
+    public class WorldManager
+    {
+        /// <summary>All reactors currently registered in the world.</summary>
+        private List<IReactor> _reactors  = new();
+
+        /// <summary>
+        /// Event subscribers indexed by event type.
+        /// Each key holds a list of callbacks to invoke when that event is raised.
+        /// </summary>
+        private Dictionary<Type, List<Delegate>> _subscribers = new();
+
+        /// <summary>
+        /// Registers a reactor in the world. Has no effect if already registered.
+        /// Called automatically by <see cref="BaseReactor.Initialize"/>.
+        /// </summary>
+        /// <param name="reactor">The reactor to register.</param>
+        public void Register(IReactor reactor)
+        {
+            if (!_reactors.Contains(reactor))
+            {
+                _reactors.Add(reactor);
+                Debug.Log($"[WorldManager] Reactor '{reactor.Name}' registered.");
+            }
+            else
+            {
+                Debug.LogWarning($"[WorldManager] Reactor '{reactor.Name}' is already registered.");
+            }
+        }
+
+        /// <summary>
+        /// Unregisters a reactor from the world. Has no effect if not found.
+        /// Called automatically by <see cref="BaseReactor.Shutdown"/>.
+        /// </summary>
+        /// <param name="reactor">The reactor to unregister.</param>
+        public void Unregister(IReactor reactor)
+        {
+            if (_reactors.Contains(reactor))
+            {
+                _reactors.Remove(reactor);
+                Debug.Log($"[WorldManager] Reactor '{reactor.Name}' unregistered.");
+            }
+            else
+            {
+                Debug.LogWarning($"[WorldManager] Tried to unregister reactor '{reactor.Name}', but it was not found.");
+            }
+        }
+
+        /// <summary>
+        /// Subscribes a callback to a specific event type.
+        /// The callback will be invoked every time <see cref="Raise{TEvent}"/> is called
+        /// with a matching event type.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type to listen to.</typeparam>
+        /// <param name="callback">The method to call when the event is raised.</param>
+        public void Subscribe<TEvent>(Action<TEvent> callback) where TEvent : IWorldEvent
+        {
+            var key = typeof(TEvent);
+            if (!_subscribers.ContainsKey(key))
+                _subscribers[key] = new List<Delegate>();
+            _subscribers[key].Add(callback);
+
+            Debug.Log($"[WorldManager] Subscribed to '{key.Name}' (method: {callback.Method.Name}).");
+        }
+
+        /// <summary>
+        /// Unsubscribes a callback from a specific event type.
+        /// Must be called in <see cref="IReactor.Shutdown"/> to avoid memory leaks.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type to stop listening to.</typeparam>
+        /// <param name="callback">The callback to remove.</param>
+        public void Unsubscribe<TEvent>(Action<TEvent> callback) where TEvent : IWorldEvent
+        {
+            var key = typeof(TEvent);
+            if (_subscribers.ContainsKey(key))
+            {
+                _subscribers[key].Remove(callback);
+                Debug.Log($"[WorldManager] Unsubscribed from '{key.Name}' (method: {callback.Method.Name}).");
+            }
+            else
+            {
+                Debug.LogWarning($"[WorldManager] Tried to unsubscribe from '{key.Name}', but no subscribers were found.");
+            }
+        }
+
+        /// <summary>
+        /// Publishes an event to all subscribers registered for its type.
+        /// Logs a warning if no subscriber is listening, which may indicate a missing initialization.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type to raise.</typeparam>
+        /// <param name="evt">The event instance to dispatch.</param>
+        public void Raise<TEvent>(TEvent evt) where TEvent : IWorldEvent
+        {
+            var key = typeof(TEvent);
+            if (!_subscribers.ContainsKey(key) || _subscribers[key].Count == 0)
+            {
+                Debug.LogWarning($"[WorldManager] Event '{key.Name}' raised but no subscribers are listening.");
+                return;
+            }
+            Debug.Log($"[WorldManager] Raising event '{key.Name}' to {_subscribers[key].Count} subscriber(s).");
+            foreach (var sub in _subscribers[key])
+                ((Action<TEvent>)sub)?.Invoke(evt);
+        }
+
+        /// <summary>
+        /// Enables or disables a registered reactor by name.
+        /// Has no effect if the reactor name is not found.
+        /// </summary>
+        /// <param name="reactorName">The <see cref="IReactor.Name"/> of the target reactor.</param>
+        /// <param name="enabled"><c>true</c> to enable, <c>false</c> to disable.</param>
+        public void SetReactorEnabled(string reactorName, bool enabled)
+        {
+            var currentReactor = _reactors.Find((reactor) => reactor.Name == reactorName);
+            if (currentReactor != null)
+            {
+                currentReactor.IsEnabled = enabled;
+                Debug.Log($"[WorldManager] Reactor '{reactorName}' set to {(enabled ? "enabled" : "disabled")}.");
+            }
+            else
+            {
+                Debug.LogWarning($"[WorldManager] SetReactorEnabled: reactor '{reactorName}' not found.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/ReactiveWorld/WorldManager.cs.meta
+++ b/Assets/Scripts/Runtime/ReactiveWorld/WorldManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed3036d599180864189d0f730961deab


### PR DESCRIPTION
- Add IWorldEvent marker interface for all typed game events
- Add AreaLightChangedEvent and StructureChangedEvent as first concrete events
- Add IReactor contract defining the lifecycle (Initialize / Shutdown)
- Add WorldManager as the central hub managing reactor registration and typed event dispatching (Subscribe / Unsubscribe / Raise)
- Add Debug.Log / LogWarning instrumentation across all WorldManager methods for traceability during development